### PR TITLE
fix richeditor can not scroll when used the crosswalk

### DIFF
--- a/richeditor/src/main/assets/style.css
+++ b/richeditor/src/main/assets/style.css
@@ -22,7 +22,7 @@ html {
 }
 
 body {
-  overflow: hidden;
+  overflow: scroll;
   display: table;
   table-layout: fixed;
   width: 100%;


### PR DESCRIPTION
It can not scrolll when use it at the crosswalk. because overflow's value is hidden.change it the scroll. the work is well.
