### PR TITLE
Add ability to disable input on editor making it readonly

### DIFF
--- a/richeditor/src/main/assets/editor.html
+++ b/richeditor/src/main/assets/editor.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
-<div id="editor" contentEditable="true"></div>
+<div id="editor" contenteditable="true"></div>
 <script type="text/javascript" src="rich_editor.js"></script>
 </body>
 </html>

--- a/richeditor/src/main/assets/rich_editor.js
+++ b/richeditor/src/main/assets/rich_editor.js
@@ -86,6 +86,10 @@ RE.setPlaceholder = function(placeholder) {
     RE.editor.setAttribute("placeholder", placeholder);
 }
 
+RE.setInputEnabled = function(inputEnabled) {
+    RE.editor.contentEditable = String(inputEnabled);
+}
+
 RE.undo = function() {
     document.execCommand('undo', false, null);
 }

--- a/richeditor/src/main/assets/style.css
+++ b/richeditor/src/main/assets/style.css
@@ -31,10 +31,6 @@ body {
 
 #editor {
   display: table-cell;
-
-  -webkit-user-select: auto !important;
-  -webkit-user-modify: read-write !important;
-
   outline: 0px solid transparent;
   background-repeat: no-repeat;
   background-position: center;

--- a/richeditor/src/main/java/jp/wasabeef/richeditor/RichEditor.java
+++ b/richeditor/src/main/java/jp/wasabeef/richeditor/RichEditor.java
@@ -253,6 +253,10 @@ public class RichEditor extends WebView {
     exec("javascript:RE.setPlaceholder('" + placeholder + "');");
   }
 
+  public void setInputEnabled(Boolean inputEnabled) {
+    exec("javascript:RE.setInputEnabled(" + inputEnabled + ")");
+  }
+
   public void loadCSS(String cssFile) {
     String jsCSSImport = "(function() {" +
         "    var head  = document.getElementsByTagName(\"head\")[0];" +

--- a/sample/src/main/java/jp/wasabeef/sample/MainActivity.java
+++ b/sample/src/main/java/jp/wasabeef/sample/MainActivity.java
@@ -23,8 +23,9 @@ public class MainActivity extends AppCompatActivity {
     //mEditor.setBackgroundColor(Color.BLUE);
     //mEditor.setBackgroundResource(R.drawable.bg);
     mEditor.setPadding(10, 10, 10, 10);
-    //    mEditor.setBackground("https://raw.githubusercontent.com/wasabeef/art/master/chip.jpg");
+    //mEditor.setBackground("https://raw.githubusercontent.com/wasabeef/art/master/chip.jpg");
     mEditor.setPlaceholder("Insert text here...");
+    //mEditor.setInputEnabled(false);
 
     mPreview = (TextView) findViewById(R.id.preview);
     mEditor.setOnTextChangeListener(new RichEditor.OnTextChangeListener() {


### PR DESCRIPTION
I have been trying to implement this editor for a little while and eventually found the need to make the input readonly. I'm aware that I could just switch out the editor for a web view to view the content but then you don't have consistency between the editor and the web view.

Using setFocusable, setClickable and setLongClickable mean that you can't select the text to copy it.

So instead I change the contentEditable property of the editor node in the JS.

I also removed the user-select and user-modify from the CSS as you were mixing two different methods by doing so and it would have required adding a class to override the default styles as well. I chose contenteditable as it has better browser support.

Let me know your thoughts.

P.S. It appears that it would fix issue #79 as well