### PR TITLE
fix url decoding ( '+' is not decoded to ' ' anymore)

### DIFF
--- a/richeditor/build.gradle
+++ b/richeditor/build.gradle
@@ -13,6 +13,13 @@ android {
   }
 }
 
+
+dependencies {
+  testCompile "junit:junit:4.12"
+  testCompile "org.robolectric:robolectric:3.1.4"
+}
+
+
 publish {
   userOrg = POM_DEVELOPER_ID
   groupId = GROUP

--- a/richeditor/build.gradle
+++ b/richeditor/build.gradle
@@ -27,7 +27,7 @@ publish {
   publishVersion = VERSION_NAME
   desc = POM_DESCRIPTION
   website = POM_URL
-  bintrayUser = BINTRAY_USER
-  bintrayKey = BINTRAY_API_KEY
+  /*bintrayUser = BINTRAY_USER
+  bintrayKey = BINTRAY_API_KEY*/
   autoPublish = false
 }

--- a/richeditor/build.gradle
+++ b/richeditor/build.gradle
@@ -27,7 +27,7 @@ publish {
   publishVersion = VERSION_NAME
   desc = POM_DESCRIPTION
   website = POM_URL
-  /*bintrayUser = BINTRAY_USER
-  bintrayKey = BINTRAY_API_KEY*/
+  bintrayUser = BINTRAY_USER
+  bintrayKey = BINTRAY_API_KEY
   autoPublish = false
 }

--- a/richeditor/src/main/java/jp/wasabeef/richeditor/RichEditor.java
+++ b/richeditor/src/main/java/jp/wasabeef/richeditor/RichEditor.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -420,13 +421,7 @@ public class RichEditor extends WebView {
     }
 
     @Override public boolean shouldOverrideUrlLoading(WebView view, String url) {
-      String decode;
-      try {
-        decode = URLDecoder.decode(url, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        // No handling
-        return false;
-      }
+      String decode = Uri.decode(url);
 
       if (TextUtils.indexOf(url, CALLBACK_SCHEME) == 0) {
         callback(decode);

--- a/richeditor/src/test/java/richeditor/UrlDecoderTest.java
+++ b/richeditor/src/test/java/richeditor/UrlDecoderTest.java
@@ -1,0 +1,23 @@
+package richeditor;
+
+import android.net.Uri;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class UrlDecoderTest {
+
+    @Test
+    public void urlDecodeTest() throws Exception {
+        String encoded = "re-callback://%20%20%3Cdiv%3E%3Cfont%20face=%22Arial%22%20size=%222%22%20color=%22#333333%22%3EDJK%20Besteck%3C/font%3E%3Cb%3E%3Cfont%20face=%22Arial%22%20size=%222%22%20color=%22#333333%22%3E&nbsp;Kenntnisse++_%20++ 下 ぁ ص%3C/font%3E%3C/b%3E%3C/div%3E%20";
+        String decoded = Uri.decode(encoded);
+
+        String test = "re-callback://  <div><font face=\"Arial\" size=\"2\" color=\"#333333\">DJK Besteck</font><b><font face=\"Arial\" size=\"2\" color=\"#333333\">&nbsp;Kenntnisse++_ ++ 下 ぁ ص</font></b></div> ";
+
+        Assert.assertEquals(test, decoded);
+    }
+
+}


### PR DESCRIPTION
We had the problem that users write a '+' in the editor. And after saving this the '+' change to a ' '. 

The java URLDecoder class has an unexpected behavior regarding the '+' character. 