### PR TITLE
修复setPlaceholder()无效BUG

### DIFF
--- a/richeditor/src/main/assets/style.css
+++ b/richeditor/src/main/assets/style.css
@@ -40,4 +40,4 @@ body {
 #editor[placeholder]:empty:not(:focus):before {
   content: attr(placeholder);
   opacity: .5;
-}}
+}


### PR DESCRIPTION
修复setPlaceholder()无效BUG
style.css 文件中  有两个}   导致方法无效