### PR TITLE
Trigger update decorations callback when focusing editor

### DIFF
--- a/richeditor/src/main/assets/rich_editor.js
+++ b/richeditor/src/main/assets/rich_editor.js
@@ -340,6 +340,7 @@ RE.focus = function() {
     selection.removeAllRanges();
     selection.addRange(range);
     RE.editor.focus();
+    RE.enabledEditingItems(null);
 }
 
 RE.blurFocus = function() {


### PR DESCRIPTION
This fixes the issue where enabled decorations are not reported after setting HTML. Newly entered text respects already active decorations but since enabled decorations callback is not fired, custom UI that could rely on the callback to show enabled decorations is not updated to reflect the correct state.